### PR TITLE
Add "const" qualifier to const pointers

### DIFF
--- a/I2C.cpp
+++ b/I2C.cpp
@@ -321,11 +321,11 @@ uint8_t I2C::write(int address, int registerAddress, int data)
   return (write((uint8_t)address, (uint8_t)registerAddress, (uint8_t)data));
 }
 
-uint8_t I2C::write(uint8_t address, uint8_t registerAddress, char *data)
+uint8_t I2C::write(uint8_t address, uint8_t registerAddress, const char *data)
 {
   uint8_t bufferLength = strlen(data);
   returnStatus = 0;
-  returnStatus = write(address, registerAddress, (uint8_t *)data, bufferLength);
+  returnStatus = write(address, registerAddress, (const uint8_t *)data, bufferLength);
   return (returnStatus);
 }
 
@@ -376,7 +376,7 @@ uint8_t I2C::write(uint8_t address, uint8_t registerAddress, uint64_t data)
   return (returnStatus);
 }
 
-uint8_t I2C::write(uint8_t address, uint8_t registerAddress, uint8_t *data, uint8_t numberBytes)
+uint8_t I2C::write(uint8_t address, uint8_t registerAddress, const uint8_t *data, uint8_t numberBytes)
 {
   returnStatus = 0;
   returnStatus = _start();
@@ -863,14 +863,14 @@ uint8_t I2C::write16(uint8_t address, uint16_t registerAddress, uint8_t data)
   }
   return (returnStatus);
 }
-uint8_t I2C::write16(uint8_t address, uint16_t registerAddress, char *data)
+uint8_t I2C::write16(uint8_t address, uint16_t registerAddress, const char *data)
 {
   uint8_t bufferLength = strlen(data);
   returnStatus = 0;
-  returnStatus = write16(address, registerAddress, (uint8_t *)data, bufferLength);
+  returnStatus = write16(address, registerAddress, (const uint8_t *)data, bufferLength);
   return (returnStatus);
 }
-uint8_t I2C::write16(uint8_t address, uint16_t registerAddress, uint8_t *data, uint8_t numberBytes)
+uint8_t I2C::write16(uint8_t address, uint16_t registerAddress, const uint8_t *data, uint8_t numberBytes)
 {
   returnStatus = 0;
   returnStatus = _start();

--- a/I2C.h
+++ b/I2C.h
@@ -99,11 +99,11 @@ public:
   uint8_t write(int, int);
   uint8_t write(uint8_t, uint8_t, uint8_t);
   uint8_t write(int, int, int);
-  uint8_t write(uint8_t, uint8_t, char *);
+  uint8_t write(uint8_t, uint8_t, const char *);
   uint8_t write(uint8_t, uint8_t, uint16_t); //Will write 2 bytes
   uint8_t write(uint8_t, uint8_t, uint32_t); //Will write 4 bytes
   uint8_t write(uint8_t, uint8_t, uint64_t); //Will write 8 bytes
-  uint8_t write(uint8_t, uint8_t, uint8_t *, uint8_t);
+  uint8_t write(uint8_t, uint8_t, const uint8_t *, uint8_t);
   uint8_t read(uint8_t, uint8_t);
   uint8_t read(int, int);
   uint8_t read(uint8_t, uint8_t, uint8_t);
@@ -114,11 +114,11 @@ public:
   //These functions will be used to write to Slaves that take 16-bit addresses
   uint8_t write16(uint8_t, uint16_t);
   uint8_t write16(uint8_t, uint16_t, uint8_t);
-  uint8_t write16(uint8_t, uint16_t, char *);
+  uint8_t write16(uint8_t, uint16_t, const char *);
   uint8_t write16(uint8_t, uint16_t, uint16_t); //Will write 2 bytes
   uint8_t write16(uint8_t, uint16_t, uint32_t); //Will write 4 bytes
   uint8_t write16(uint8_t, uint16_t, uint64_t); //Will write 8 bytes
-  uint8_t write16(uint8_t, uint16_t, uint8_t *, uint8_t);
+  uint8_t write16(uint8_t, uint16_t, const uint8_t *, uint8_t);
   //These functions will be used to read from Slaves that take 16-bit addresses
   uint8_t read16(uint8_t, uint16_t, uint8_t);
   uint8_t read16(uint8_t, uint16_t, uint8_t, uint8_t *);


### PR DESCRIPTION
When someone creates a const pointer, it's not possible to pass it to
a function expecting a non-const pointer because it would result in an
"invalid conversion" in C++